### PR TITLE
Remove duplicate code for downloading SD15_WEIGHTS

### DIFF
--- a/script/download_weights
+++ b/script/download_weights
@@ -33,11 +33,6 @@ if os.path.exists(TMP_CACHE):
     shutil.rmtree(TMP_CACHE)
 os.makedirs(TMP_CACHE)
 
-p = StableDiffusionPipeline.from_pretrained(
-            "runwayml/stable-diffusion-v1-5", torch_dtype=torch.float16, cache_dir=TMP_CACHE
-        )
-p.save_pretrained(SD15_WEIGHTS)
-
 for name, model in AUX_IDS.items():
     aux = ControlNetModel.from_pretrained(
         model,


### PR DESCRIPTION
I'm new to Cog and Python, so I could be wrong. But it seems like the download script is trying to download the SD15 weights twice. 

Since it's cached, it doesn't impact performance. But it seems redundant.

https://github.com/anotherjesse/multi-control/blob/12a5583009936e30e31648926a8b3a5acb2182ca/script/download_weights#L36-L39

https://github.com/anotherjesse/multi-control/blob/12a5583009936e30e31648926a8b3a5acb2182ca/script/download_weights#L60-L61